### PR TITLE
Make LZW recompression match original data

### DIFF
--- a/js/randomizer.lzw.js
+++ b/js/randomizer.lzw.js
@@ -299,20 +299,11 @@ function compressLZW(data)
 
         // The decompressor supports a special case when cw == cw_next it repeats the
         // last cw's string, then repeats the first byte of that string.
-        var special = null;
-        if(prevCw >= BASE_CW)
-        {
-            var prevString = dictionary[prevCw - BASE_CW];
-            special = concatByteArrays([prevString, prevString.subarray(0, 1)]);
-        }
-        else
-        {
-            special = null;
-        }
+        var special = concatByteArrays([prev, prev.subarray(0,1)]);
 
         var string;
         var cw;
-        if(special != null && special.length >= longestLen && dataStartsWith(special))
+        if(special.length >= longestLen && dataStartsWith(special))
         {
             // The special case was better than a dictionary match, use it
             string = special;


### PR DESCRIPTION
I originally thought that the "special" command (using a not-yet-defined `cw` value) was only for repeating strings of characters from the LZW dictionary, as that's how I saw it used in the intro graphics. It turns out it also works for individual characters, e.g. `01 01 01` is encoded as `01 <special>`.

With this fix the re-compressed output exactly matches the original data from the ROM.