### PR TITLE
Fix symbol hash. Fix "some caves" preset.

### DIFF
--- a/js/randomizer.preset.js
+++ b/js/randomizer.preset.js
@@ -754,7 +754,7 @@ function preset_some_caves() //some caves
   	$('#randomize_locations_joinable_jaana').prop('checked', true).triggerHandler("click");
   	$('#randomize_locations_joinable_julia').prop('checked', true).triggerHandler("click");
   	$('#randomize_locations_joinable_katrina').prop('checked', true).triggerHandler("click");
-  	$('#randomize_locations_joinable_leoden').prop('checked', true).triggerHandler("click");
+  	$('#randomize_locations_joinable_leodon').prop('checked', true).triggerHandler("click");
   	$('#randomize_locations_joinable_leonna').prop('checked', true).triggerHandler("click");
   	$('#randomize_locations_joinable_seggal').prop('checked', true).triggerHandler("click");
   	$('#randomize_locations_joinable_sentri').prop('checked', true).triggerHandler("click");

--- a/js/randomizer.text.js
+++ b/js/randomizer.text.js
@@ -122,7 +122,7 @@ var TEXT_MAPPING =
 	"\uE034": 0x02,
 };
 
-function writeTextToAddress(rom, inAddress, inLength, inText)
+function writeTextToAddress(rom, inAddress, inLength, inText, nullPad = false)
 {
 	//console.log('writing ' + inText);
 
@@ -130,8 +130,9 @@ function writeTextToAddress(rom, inAddress, inLength, inText)
 	{
 		for (var i = 0; i < inLength; ++i)
 		{
-			//rom[inAddress + i] = TEXT_MAPPING[" "];
-			rom[inAddress + i] = 0x00;
+			//changing to always 0x00 broke symbol hash
+			//added optional parameter for things like item names that need to be null teriminated
+			nullPad ? rom[inAddress + i] = 0x00 : rom[inAddress + i] = TEXT_MAPPING[" "];
 		}
 	}
 
@@ -333,21 +334,24 @@ function fixText(rom, itemsRandomized)
 	writeTextToAddress(rom, 0x0E225, 6, "R.Prot"); //Ring of Protection
 	writeTextToAddress(rom, 0x0E22C, 6, "R.Regn"); //Ring of Regeneration
 	writeTextToAddress(rom, 0x0E233, 6, "R.Invs"); //Ring of Invisibility
-	writeTextToAddress(rom, 0x0D044, 10, "M.Honesty"); //Moonstone of Honesty
+
+	//Moonstone names. Must end with 0x00
+	//Additional parameter set to true is to use 0x00 instead of 0x5F (space) to clear area in the rom
+	writeTextToAddress(rom, 0x0D044, 10, "M.Honesty", true); //Moonstone of Honesty
 	rom.set([0x44, 0xD0], 0xDF7F); //Set item name pointer for Moonstone of Honesty
-	writeTextToAddress(rom, 0x0D04E, 13, "M.Compassion"); //Moonstone of Compassion
+	writeTextToAddress(rom, 0x0D04E, 13, "M.Compassion", true); //Moonstone of Compassion
 	rom.set([0x4E, 0xD0], 0xDF81); //Set item name pointer for Moonstone of Compassion
-	writeTextToAddress(rom, 0x0D05B, 8, "M.Valor"); //Moonstone of Valor
+	writeTextToAddress(rom, 0x0D05B, 8, "M.Valor", true); //Moonstone of Valor
 	rom.set([0x5B, 0xD0], 0xDF83); //Set item name pointer for Moonstone of Valor
-	writeTextToAddress(rom, 0x0D063, 10, "M.Justice"); //Moonstone of Justice
+	writeTextToAddress(rom, 0x0D063, 10, "M.Justice", true); //Moonstone of Justice
 	rom.set([0x63, 0xD0], 0xDF85); //Set item name pointer for Moonstone of Justice
-	writeTextToAddress(rom, 0x0D06D, 12, "M.Sacrifice"); //Moonstone of Sacrifice
+	writeTextToAddress(rom, 0x0D06D, 12, "M.Sacrifice", true); //Moonstone of Sacrifice
 	rom.set([0x6D, 0xD0], 0xDF87); //Set item name pointer for Moonstone of Sacrifice
-	writeTextToAddress(rom, 0x0D079, 8, "M.Honor"); //Moonstone of Honor
+	writeTextToAddress(rom, 0x0D079, 8, "M.Honor", true); //Moonstone of Honor
 	rom.set([0x79, 0xD0], 0xDF89); //Set item name pointer for Moonstone of Honor
-	writeTextToAddress(rom, 0x0D081, 9, "M.Spirit"); //Moonstone of Spirituality
+	writeTextToAddress(rom, 0x0D081, 9, "M.Spirit", true); //Moonstone of Spirituality
 	rom.set([0x81, 0xD0], 0xDF8B); //Set item name pointer for Moonstone of Spirituality
-	writeTextToAddress(rom, 0x0D08A, 11, "M.Humility"); //Moonstone of Humility
+	writeTextToAddress(rom, 0x0D08A, 11, "M.Humility", true); //Moonstone of Humility
 	rom.set([0x8A, 0xD0], 0xDF8D); //Set item name pointer for Moonstone of Humility
 
 	if(itemsRandomized == true)


### PR DESCRIPTION
Changing the padding character to 0x00 (needed for item names) broke symbol hashes. Went back to " " (0x5F) unless optional parameter is set to true.

Leodon is now properly selected in the "some caves" preset.